### PR TITLE
Add badge row and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to configgle
+
+Thanks for helping improve configgle.
+
+## Why this file exists
+
+configgle accepts public changes through a generated public repository while the source tree
+stays canonical. Contributors need to know how to validate changes locally and which branches are
+safe to edit.
+
+## Development setup
+
+Requires Python 3.12 and uv.
+
+```bash
+uv sync --all-groups
+uv run pytest
+```
+
+Before opening a pull request, run:
+
+```bash
+uv sync --all-groups
+uv run ruff check --no-fix --no-cache .
+uv run ruff format --check --no-cache .
+uv run codespell .
+uv run ty check
+uv run basedpyright configgle tests
+uv run pytest
+uv run python -c "import configgle"
+uv build
+```
+
+## Testing notes
+
+Tests are organized into tiers via pytest markers. The default run (plain `uv run pytest`)
+deselects the following, which must be requested explicitly with `-m`:
+
+- `ci_smoke` -- slower package/CLI smoke tests run explicitly in CI
+- `cuda` -- tests that require a real CUDA device
+- `integration` -- tests that require networking or external CLIs
+- `performance` -- timing-sensitive tests
+
+## Public contribution flow
+
+The public repository is synchronized with the canonical source tree. Public changes should be
+made on normal contributor branches. After validation, the sync workflow imports accepted changes
+back to the source repository for review.
+
+Do not edit generated `configgle/export/*` branches directly.
+
+## Pull request expectations
+
+- Keep changes focused.
+- Include tests for behavior changes.
+- Update README or docs when public behavior changes.
+- Do not include secrets, private credentials, generated caches, or local environment files.
+- See [AI_POLICY.md](AI_POLICY.md) for our policy on AI-assisted contributions -- in short, a
+  human must be in the loop, and we do not accept autonomous-agent-authored pull requests.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
 # configgle🤭
+
+[![PyPI version](https://img.shields.io/pypi/v/configgle.svg)](https://pypi.org/project/configgle/)
+[![CI](https://github.com/rekursiv-ai/configgle/actions/workflows/package-validation.yml/badge.svg?branch=main)](https://github.com/rekursiv-ai/configgle/actions/workflows/package-validation.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](pyproject.toml)
+
 Hierarchical experiment configuration using pure Python dataclasses with typed
 factory methods, covariant protocols, inheritance support, and tooling for
 pretty printing, autodecorating, updating, and semi-deep copying.
 
-## Installation
+> *If you're tired of YAML files and stringly-typed keys for ML experiment config and want plain,
+> typed Python dataclasses your IDE and type-checker actually understand.*
+
+## Install
 
 ```bash
 python -m pip install configgle
 ```
 
-## Example
+## Quickstart
 
 ```python
 from configgle import Fig
@@ -440,6 +449,16 @@ If you find our work useful, please consider citing:
       url={https://github.com/rekursiv-ai/configgle},
 }
 ```
+
+## See also
+
+Sibling libraries in the [rekursiv-ai](https://github.com/rekursiv-ai) family:
+
+- [priml](https://github.com/rekursiv-ai/priml) — Composable PyTorch building blocks: models, optimizers, losses, and a step-based training loop.
+- [trackinizer](https://github.com/rekursiv-ai/trackinizer) — Centralized agent database for tracking inquiries, work, and the evidence behind conclusions.
+- [sagent](https://github.com/rekursiv-ai/sagent) — The self-mutating multi-provider coding-agent CLI and typed Python library.
+- [madcatter](https://github.com/rekursiv-ai/madcatter) — Rich-based Markdown renderer for the terminal; ships the `mdcat` CLI.
+- [wesearch](https://github.com/rekursiv-ai/wesearch) — Web search, resilient page fetch, and scholarly-paper lookup without a browser stack.
 
 ## License
 


### PR DESCRIPTION
Library clean up for open source 

- README: house-style badge row (PyPI, CI, license, Python) under the H1
- CONTRIBUTING.md: previously absent despite Issues/PR links in pyproject; adapted from the wesearch template to configgle's actual sync workflow (configgle/export/ branch prefix verified in sync-to-source.yml) and explicitly deferring to AI_POLICY.md
