### PR TITLE
Correct Makeable protocol membership in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,10 @@ becomes unnecessary.
 ### Covariant `Makeable` protocol
 
 `Makeable[T]` is a covariant protocol satisfied by any `Fig`, `InlineConfig`,
-or custom class with `make()`, `finalize()`, and `update()`. Because it's
-covariant, `Makeable[Dog]` is assignable to `Makeable[Animal]`:
+or custom class exposing `make()`, `finalize()`, `update()`, plus the
+`_finalized` and `parent_class` members (`Maker` and `InlineConfig` provide all
+five). Because it's covariant, `Makeable[Dog]` is assignable to
+`Makeable[Animal]`:
 
 ```python
 from configgle import Makeable

--- a/configgle/__init__.py
+++ b/configgle/__init__.py
@@ -251,7 +251,9 @@ Deserialization imports the modules named in the payload, so treat a
 serialized config like ``pickle``: load only trusted data.
 
 ``Makeable`` -- Runtime-checkable ``Protocol`` defining the config
-interface (``make()``, ``finalize()``, ``update()``). Also aliased as
+interface: ``make()``, ``finalize()``, ``update()``, plus the ``_finalized``
+and ``parent_class`` members. All five are required, so ``isinstance``
+rejects a class carrying only the three methods. Also aliased as
 ``Configurable``.
 
 ``Maker`` subclasses also integrate with IPython/Jupyter via

--- a/configgle/custom_types.py
+++ b/configgle/custom_types.py
@@ -91,7 +91,13 @@ class DataclassLike(Protocol):
 
 @runtime_checkable
 class Makeable(Protocol[_T_co]):
-    """Protocol for objects with make(), finalize(), and update() methods."""
+    """Protocol for config-like objects.
+
+    Requires the ``make()``/``finalize()``/``update()`` methods *and* the
+    ``_finalized`` and ``parent_class`` members declared below, so
+    ``isinstance(obj, Makeable)`` is False for a class that defines only the
+    three methods.
+    """
 
     # Read-only: implementers store `_finalized` however they like (a writable
     # slot on `Maker`, a mutable dataclass field on `InlineConfig`, or a frozen

--- a/tests/fig_test.py
+++ b/tests/fig_test.py
@@ -559,6 +559,31 @@ def test_inline_config_satisfies_makeable():
     assert partial_cfg.make()() == 42
 
 
+def test_makeable_requires_more_than_the_three_methods():
+    """make/finalize/update alone do not satisfy Makeable.
+
+    Guards the documented contract: _finalized and parent_class are part of
+    the protocol, so a three-method class is rejected by isinstance.
+    """
+
+    class ThreeMethods:
+        def make(self) -> object:
+            return object()
+
+        def finalize(self) -> Self:
+            return self
+
+        def update(self, *_args: object, **_kwargs: object) -> Self:
+            return self
+
+    class FiveMembers(ThreeMethods):
+        _finalized = False
+        parent_class = None
+
+    assert not isinstance(ThreeMethods(), Makeable)
+    assert isinstance(FiveMembers(), Makeable)
+
+
 def test_require_defaults_error_message():
     """Test that missing default raises TypeError with helpful message."""
     with pytest.raises(TypeError, match="has no default value"):


### PR DESCRIPTION
The docs described `Makeable` as satisfied by any class with `make()`, `finalize()`, and `update()`, but the runtime-checkable protocol also requires `_finalized` and `parent_class`; `isinstance` returns False without them.

Updates README, the package docstring, and the protocol docstring, and adds a test asserting a three-method class is rejected while a five-member one is accepted.